### PR TITLE
remove use of ansible_ssh_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python script to parse /etc/hosts for Ansible Inventory
 
 ## Overview
 
-This sctipt collects all hosts from /etc/hosts into `targets` group and set its ip address as `ansible_hostname`
+This sctipt collects all hosts from /etc/hosts into `targets` group.
 
 ```bash
 $ cat /etc/hosts
@@ -18,14 +18,7 @@ $ cat /etc/hosts
 $ ansible-inventory -i etchosts-inventory/hosts.py --list
 {
     "_meta": {
-        "hostvars": {
-            "web1": {
-                "ansible_hostname": "192.168.1.1"
-            },
-            "web2": {
-                "ansible_hostname": "192.168.1.2"
-            }
-        }
+        "hostvars": {}
     },
     "all": {
         "children": [

--- a/hosts.py
+++ b/hosts.py
@@ -54,9 +54,6 @@ def makeInventory(f):
             continue
 
         inventories['targets']['hosts'].append(hostname)
-        inventories['_meta']['hostvars'][hostname] = {
-            'ansible_hostname': str(ip)
-        }
         hostlist.append(hostname)
     return inventories
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -17,33 +17,20 @@ def test_omitreserved():
 def test_basic():
     for num in range(1, 4):
         assert 'basic' + str(num) in inventory['targets']['hosts']
-    assert inventory['_meta']['hostvars']['basic1']['ansible_hostname'] == '192.168.0.1'
-    assert inventory['_meta']['hostvars']['basic2']['ansible_hostname'] == '192.168.0.2'
-    assert inventory['_meta']['hostvars']['basic3']['ansible_hostname'] == '192.168.0.3'
 
 
 def test_tabs():
     assert 'tab1' in inventory['targets']['hosts']
-    assert inventory['_meta']['hostvars']['tab1']['ansible_hostname'] == '192.168.0.4'
 
 
 def test_multispace():
     for num in range(1, 3):
         assert 'multispace' + str(num) in inventory['targets']['hosts']
         assert 'multitabs' + str(num) in inventory['targets']['hosts']
-    assert inventory['_meta']['hostvars']['multispace1']['ansible_hostname'] == '192.168.0.5'
-    assert inventory['_meta']['hostvars']['multispace2']['ansible_hostname'] == '192.168.0.6'
-    assert inventory['_meta']['hostvars']['multitabs1']['ansible_hostname'] == '192.168.0.7'
-    assert inventory['_meta']['hostvars']['multitabs2']['ansible_hostname'] == '192.168.0.8'
 
 
 def test_multihosts():
     assert 'multihost1' in inventory['targets']['hosts']
-    assert inventory['_meta']['hostvars']['multihost1']['ansible_hostname'] == '192.168.0.9'
     for num in range(2, 4):
         assert 'multihost' + str(num) not in inventory['targets']['hosts']
 
-
-def test_dup():
-    assert 'dup1' in inventory['targets']['hosts']
-    assert inventory['_meta']['hostvars']['dup1']['ansible_hostname'] == '192.168.0.10'

--- a/tests/testhosts
+++ b/tests/testhosts
@@ -31,10 +31,6 @@ fe00::    ip6-localnet
 ### first hostname should be taken
 192.168.0.9 multihost1 multihost2 multihost3
 
-### duplicated hosts should be omitted
-192.168.0.10 dup1
-192.168.0.11 dup1  # This should be omitted
-
 ### broken lines should be omitted
-192.168.0.12 
+192.168.0.10 
 foobar


### PR DESCRIPTION
remove the use of `ansible_ssh_host`
Since some people including myself use ssh_config and it should be set for hostname, not its IP address.
So I think this is closer for the real use cases.